### PR TITLE
use env param insteed 11434

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -7,7 +7,7 @@ ollama serve &
 echo "Waiting for Ollama server to initialize..."
 max_attempts=30
 attempt=0
-while ! curl -s http://localhost:11434/api/tags >/dev/null; do
+while ! curl -s http://localhost:${OLLAMA_PORT:-11434}/api/tags >/dev/null; do
     sleep 1
     attempt=$((attempt + 1))
     if [ $attempt -eq $max_attempts ]; then


### PR DESCRIPTION
if OLLAMA_PORT other than 11434, then the `docker-entrypoint.sh` will make wrong exit